### PR TITLE
Return a slice, not a vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 0.2.0 - 2020-12-28
+
+- `Layer::Index` and `Layer::IndexMut` not return a reference to slice, not vector.
+
 ## 0.1.2 - 2020-12-28
 
 - Fix that the pixel is not redrawn correctly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screen_layer"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["toku-sa-n <tokusan441@gmail.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,7 @@ impl Layer {
 /// Layer can index into each pixels.
 impl Index<usize> for Layer {
     /// `None` represents the pixel is transparent.
-    type Output = Vec<Option<RGB8>>;
+    type Output = [Option<RGB8>];
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.buf[index]


### PR DESCRIPTION
- fix: return a slice, not a vector
- chore: bump the version to 0.2.0

bors r+
